### PR TITLE
feat: apply brand color accents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,8 +177,20 @@ export default function App() {
           ))}
         </div>
         <div className="flex gap-3 mt-4">
-          <button onClick={resetGame} className="px-4 py-3 rounded-2xl shadow bg-white text-sm">リセット</button>
+          <button
+            onClick={resetGame}
+            className="px-4 py-3 rounded-2xl shadow text-sm bg-brand-600 text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+          >
+            リセット
+          </button>
         </div>
+        {toast && (
+          <div className="fixed bottom-4 inset-x-0 flex justify-center">
+            <div className="px-4 py-2 rounded-2xl shadow bg-brand-600 text-white">
+              {toast}
+            </div>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,13 @@
+import colors from "tailwindcss/colors";
+
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        brand: colors.violet,
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- style reset button with brand color and focus ring
- show toast messages using brand color
- define reusable `brand` color palette in Tailwind config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17d87cf40832ab5c6174b01825612